### PR TITLE
Fix i18n support / remove unused import

### DIFF
--- a/generators/app/templates/src/main/java/package/service/_ElasticsearchIndexService.java.ejs
+++ b/generators/app/templates/src/main/java/package/service/_ElasticsearchIndexService.java.ejs
@@ -15,7 +15,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.scheduling.annotation.Async;

--- a/generators/app/templates/src/main/webapp/app/admin/elasticsearch-reindex/_elasticsearch-reindex.component.ts.ejs
+++ b/generators/app/templates/src/main/webapp/app/admin/elasticsearch-reindex/_elasticsearch-reindex.component.ts.ejs
@@ -1,8 +1,5 @@
 import { Component } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-<%_ if (enableTranslation && requiresSetLocation) { _%>
-import { JhiLanguageService } from 'ng-jhipster';
-<%_ } _%>
 
 import { ElasticsearchReindexModalComponent } from './elasticsearch-reindex-modal.component';
 import { ElasticsearchReindexSelectedModalComponent } from './elasticsearch-reindex-selected-modal.component';
@@ -17,15 +14,7 @@ export class ElasticsearchReindexComponent {
     reindexType: string;
     checks: { [key: string]: boolean } = {};
 
-    constructor(
-        <%_ if (enableTranslation && requiresSetLocation) { _%>
-        private jhiLanguageService: JhiLanguageService,
-        <%_ } _%>
-        private modalService: NgbModal
-    ) {
-      <%_ if (enableTranslation && requiresSetLocation) { %>
-        this.jhiLanguageService.setLocations(['elasticsearch-reindex']);
-      <%_ } _%>
+    constructor(private modalService: NgbModal) {
         this.reindexType = 'all';
         this.entities = [
     <%_ if (applicationType === 'monolith' || applicationType === 'microservice') {


### PR DESCRIPTION
I would like to propose fixes for two issues:

If latest git version is used with i18n support enabled, you get this error:
```
Welcome to the JHipster es-entity-reindexer generator! v1.0.1

WARNING! src/main/webapp/app/admin/elasticsearch-reindex/_elasticsearch-reindex.component.ts.ejs
Unhandled promise rejection at:
ReferenceError: [...]\node_modules\generator-jhipster-es-entity-reindexer\generators\app\templates\src\main\webapp\app\admin\elasticsearch-reindex\_elasticsearch-reindex.component.ts.ejs:3
    1| import { Component } from '@angular/core';
    2| import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 >> 3| <%_ if (enableTranslation && requiresSetLocation) { _%>
    4| import { JhiLanguageService } from 'ng-jhipster';
    5| <%_ } _%>
    6|
```

requiresSetLocation is not defined`

This seems to be a leftover of older JHipster versions. I tested with JHipster 7.9.3.

And in ElasticsearchIndexService.java an unused import can be removed.