### PR TITLE
Bugfixes for application properties issues

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,6 +1,7 @@
 const chalk = require('chalk');
 const semver = require('semver');
 const fs = require('fs');
+const _ = require('lodash');
 const BaseGenerator = require('generator-jhipster/generators/generator-base');
 const { SERVER_MAIN_SRC_DIR, CLIENT_MAIN_SRC_DIR, MAIN_DIR } = require('generator-jhipster/generators/generator-constants');
 const packagejs = require('../../package.json');
@@ -107,14 +108,18 @@ module.exports = class extends BaseGenerator {
          *  WRITE TEMPLATES
          */
 
-        const appyamlDestination = `${MAIN_DIR}/resources/config/application.yml`;
-        let applicationFile = fs.readFileSync(appyamlDestination, 'utf-8');
-        this.render('src/main/resources/config/_application.yml.ejs', res => {
-            applicationFile += res;
-            fs.writeFileSync(appyamlDestination, applicationFile);
-        });
-
         if (!this.skipServer) {
+            const appyamlDestination = `${MAIN_DIR}/resources/config/application.yml`;
+            let applicationFile = fs.readFileSync(appyamlDestination, 'utf-8');
+            if (!applicationFile.includes('    reindex-on-startup')) {
+                this.render('src/main/resources/config/_application.yml.ejs', res => {
+                    applicationFile += res;
+                    fs.writeFileSync(appyamlDestination, applicationFile);
+                });
+            }
+
+            this.humanizedBaseName = _.startCase(this.baseName);
+
             this.template(
                 'src/main/java/package/web/rest/_ElasticsearchIndexResource.java.ejs',
                 `${javaDir}/web/rest/ElasticsearchIndexResource.java`,

--- a/generators/app/templates/src/main/java/package/config/_ApplicationProperties.java.ejs
+++ b/generators/app/templates/src/main/java/package/config/_ApplicationProperties.java.ejs
@@ -3,7 +3,7 @@ package <%=packageName%>.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
-* Properties specific to Android Software Portal.
+* Properties specific to <%=humanizedBaseName%>.
 * <p>
 * Properties are configured in the {@code application.yml} file.
 * See {@link tech.jhipster.config.JHipsterProperties} for a good example.
@@ -15,7 +15,7 @@ public class ApplicationProperties {
     public Elasticsearch getElasticsearch() {
         return elasticsearch;
     }
-    
+
     public static class Elasticsearch {
         private boolean reindexOnStartup;
 

--- a/generators/app/templates/src/main/java/package/web/rest/_ElasticsearchIndexResource.java.ejs
+++ b/generators/app/templates/src/main/java/package/web/rest/_ElasticsearchIndexResource.java.ejs
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URISyntaxException;
 import java.util.List;
 
 /**
@@ -42,7 +41,7 @@ public class ElasticsearchIndexResource {
     @PostMapping("/elasticsearch/index")
     @Timed
     @Secured(AuthoritiesConstants.ADMIN)
-    public ResponseEntity<Void> reindexAll() throws URISyntaxException {
+    public ResponseEntity<Void> reindexAll() {
         log.info("REST request to reindex Elasticsearch by user : {}, all entities", SecurityUtils.getCurrentUserLogin());
         elasticsearchIndexService.reindexSelected(null, true);
         return ResponseEntity.accepted()
@@ -56,7 +55,7 @@ public class ElasticsearchIndexResource {
     @PostMapping("/elasticsearch/selected")
     @Timed
     @Secured(AuthoritiesConstants.ADMIN)
-    public ResponseEntity<Void> reindexSelected(@RequestBody List<String> selectedEntities) throws URISyntaxException {
+    public ResponseEntity<Void> reindexSelected(@RequestBody List<String> selectedEntities) {
         log.info("REST request to reindex Elasticsearch by user : {}, entities: {}", SecurityUtils.getCurrentUserLogin(), selectedEntities);
         elasticsearchIndexService.reindexSelected(selectedEntities, false);
         return ResponseEntity.accepted()

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "4.1.0",
         "generator-jhipster": ">=7.0.0",
+        "lodash": "4.17.21",
         "semver": "7.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "chalk": "4.1.0",
     "generator-jhipster": ">=7.0.0",
+    "lodash": "4.17.21",
     "semver": "7.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Thank you for your work on application properties. I found some smaller issues and I would like to provide a PR:

- the application.yml patch was reapplied when regenerating the application
- the application.yml patch should only be applied when "skipServer" option is not enabled
- the application name was ignored in the ApplicationProperties.java-template (same logic as in generator-jhipster)

And I fixed an issue found with sonarqube: "Remove the declaration of thrown exception 'java.net.URISyntaxException', as it cannot be thrown from method's body.".

Is there any reason not to use new application properties needles api introduced in jhipster > 7.9.x? You are overriding the needles in your ApplicationProperties.java-template. This may cause conflicts if your blueprint is used together with other blueprints using the new application properties needles api.